### PR TITLE
add trip destroy when a trip name is added but no tags are added

### DIFF
--- a/localeyes/app/controllers/trips_controller.rb
+++ b/localeyes/app/controllers/trips_controller.rb
@@ -30,6 +30,7 @@ def create
       @trip.tags << new_tag
     end
     if @trip.tags.length < 1
+      @trip.destroy
       @errors = ["Trip must have at least one tag.", "Please add one tag to continue."]
       render 'new'
     else


### PR DESCRIPTION
@hannataylor @ChristynBudzyna @elan71592 
- add trip destroy to Trips controller for when a trip name is added but no tags; prevents nil information being added to the database
