### PR TITLE
Created new migrations for messages, availability, requests, and flags

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,4 +2,6 @@ class Comment < ActiveRecord::Base
   belongs_to :trip
   belongs_to :user
 
+  has_many :flags, as: :flaggable
+
 end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,0 +1,6 @@
+class Flag < ActiveRecord::Base
+  validates :flagged, presence: true
+
+  belongs_to :user
+  belongs_to :flaggable, polymorphic: true
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,0 +1,4 @@
+class Request < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :trip
+end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -8,6 +8,9 @@ class Trip < ActiveRecord::Base
   has_many :tags, through: :trip_tags
   has_many :favorites
   has_many :user_favorites, through: :favorites, source: :user
+  has_many :requests
+  has_many :user_requests, through: :requests, source: :user
+  has_many :flags, as: :flaggable
 
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,9 @@ class User < ActiveRecord::Base
   has_many :comments
   has_many :favorites
   has_many :favorited_trips, through: :favorites, source: :trip
+  has_many :requests
+  has_many :requested_trips, through: :requests, source: :trip
+  has_many :flags
 
   validates :first_name, :last_name, presence: true
 

--- a/db/migrate/20160606003744_add_allow_messages_to_users.rb
+++ b/db/migrate/20160606003744_add_allow_messages_to_users.rb
@@ -1,0 +1,5 @@
+class AddAllowMessagesToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :allow_messages, :boolean, :default => true
+  end
+end

--- a/db/migrate/20160606003914_add_available_to_users.rb
+++ b/db/migrate/20160606003914_add_available_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvailableToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :available, :boolean, :default => false
+  end
+end

--- a/db/migrate/20160606004349_create_requests.rb
+++ b/db/migrate/20160606004349_create_requests.rb
@@ -1,0 +1,11 @@
+class CreateRequests < ActiveRecord::Migration
+  def change
+    create_table :requests do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :trip, index: true, foreign_key: true
+      t.boolean :open, default: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160606004946_create_flags.rb
+++ b/db/migrate/20160606004946_create_flags.rb
@@ -1,0 +1,11 @@
+class CreateFlags < ActiveRecord::Migration
+  def change
+    create_table :flags do |t|
+      t.boolean :flagged, default: false
+      t.references :user, foreign_key: true
+      t.references :flaggable, polymorphic: true, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160605224620) do
+ActiveRecord::Schema.define(version: 20160606004946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,17 @@ ActiveRecord::Schema.define(version: 20160605224620) do
 
   add_index "favorites", ["trip_id"], name: "index_favorites_on_trip_id", using: :btree
   add_index "favorites", ["user_id"], name: "index_favorites_on_user_id", using: :btree
+
+  create_table "flags", force: :cascade do |t|
+    t.boolean  "flagged",        default: false
+    t.integer  "user_id"
+    t.integer  "flaggable_id"
+    t.string   "flaggable_type"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+  end
+
+  add_index "flags", ["flaggable_type", "flaggable_id"], name: "index_flags_on_flaggable_type_and_flaggable_id", using: :btree
 
   create_table "locations", force: :cascade do |t|
     t.string   "name"
@@ -107,6 +118,17 @@ ActiveRecord::Schema.define(version: 20160605224620) do
   add_index "mailboxer_receipts", ["notification_id"], name: "index_mailboxer_receipts_on_notification_id", using: :btree
   add_index "mailboxer_receipts", ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type", using: :btree
 
+  create_table "requests", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "trip_id"
+    t.boolean  "open",       default: true
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "requests", ["trip_id"], name: "index_requests_on_trip_id", using: :btree
+  add_index "requests", ["user_id"], name: "index_requests_on_user_id", using: :btree
+
   create_table "tags", force: :cascade do |t|
     t.string   "name",       null: false
     t.datetime "created_at", null: false
@@ -164,6 +186,8 @@ ActiveRecord::Schema.define(version: 20160605224620) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
+    t.boolean  "allow_messages",         default: true
+    t.boolean  "available",              default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
@@ -173,10 +197,13 @@ ActiveRecord::Schema.define(version: 20160605224620) do
   add_foreign_key "comments", "users"
   add_foreign_key "favorites", "trips"
   add_foreign_key "favorites", "users"
+  add_foreign_key "flags", "users"
   add_foreign_key "locations", "trips"
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
   add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "requests", "trips"
+  add_foreign_key "requests", "users"
   add_foreign_key "trip_tags", "tags"
   add_foreign_key "trip_tags", "trips"
   add_foreign_key "trips", "users"


### PR DESCRIPTION
- Allow messages: boolean so users can turn off messaging. Defaults to true
- Add availability to users so they can select if they want to make themselves available to tour people in person
- Created Requests: Works exactly like favorites so users can mark that they want to request the creator to take them on a tour in person
- Created flags so users can flag inappropriate comments or trips so the admins can remove them.
