### PR TITLE
Messaging comment clean up

### DIFF
--- a/app/assets/javascripts/location_handler.js
+++ b/app/assets/javascripts/location_handler.js
@@ -12,7 +12,7 @@ $(document).ready(function() {
     })
     .done(function(response){
       $("#saved-location-holder").append(response);
-      $("#new-location").find(".card").remove();
+      $("#new-location").find(".card").closest(".row").remove();
       $('input').val('');
       if($("#saved-location-holder").children().length >= 4) {
         $(".finish-trip-message").hide();

--- a/app/assets/javascripts/trip_show_handlers.js
+++ b/app/assets/javascripts/trip_show_handlers.js
@@ -92,6 +92,9 @@ $(document).ready(function() {
       type: type,
       data: data
     }).done(function(response) {
+      if ($(".creator-comments-container").children().length === 2) {
+        $(this).parent().parent().find(".creator-comments-container").find(".no-comments-message").hide();
+      }
       $(this).siblings().show();
       $(this).parent().parent().find(".creator-comments-container").append(response);
       $(this).remove();
@@ -113,7 +116,10 @@ $(document).ready(function() {
       url: url,
       type: type
     }).done(function(response){
-      $(this).parent().remove();
+      $(this).closest("div").remove();
+      if ($(".creator-comments-container").children().length === 2) {
+        $(".creator-comments-container").find(".no-comments-message").show();
+      };
     }.bind(this));
   });
 
@@ -146,6 +152,9 @@ $(document).ready(function() {
       type: type,
       data: data
     }).done(function(response) {
+      if ($(".not-creator-comments-container").children().length === 2) {
+        $(this).parent().parent().find(".not-creator-comments-container").find(".no-comments-message").hide();
+      }
       $(this).siblings().show();
       $(this).parent().parent().find(".not-creator-comments-container").append(response);
       $(this).remove();
@@ -167,7 +176,10 @@ $(document).ready(function() {
       url: url,
       type: type
     }).done(function(response){
-      $(this).parent().remove();
+      $(this).closest("div").remove();
+      if ($(".not-creator-comments-container").children().length === 2) {
+        $(".not-creator-comments-container").find(".no-comments-message").show();
+      };
     }.bind(this));
   });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -166,6 +166,15 @@ h5 {
   font-weight: lighter;
 }
 
+textarea:focus {
+  border-bottom: 1px solid #0288d1 !important;
+  box-shadow: 0 1px 0 0 #0288d1 !important;
+}
+
+textarea.materialize-textarea:focus:not([readonly]) + label {
+  color: #0288d1 !important;
+}
+
 .input-field input[type=text]:focus {
   border-bottom: 1px solid #03a9f4 ;
   box-shadow: 0 1px 0 0 #03a9f4 ;
@@ -482,4 +491,12 @@ margin-bottom: 0;
 
 p.small-text {
   font-size: 1em;
+}
+
+.card-content .message-body {
+  word-wrap: break-word;
+}
+
+.hidden-comments-message {
+  display: none;
 }

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -67,6 +67,8 @@ class TripsController < ApplicationController
     else
       @locations = @trip.locations
       @comment = Comment.new
+      @creator_comments = @trip.comments.where( user_id: @trip.creator.id)
+      @user_comments = @trip.comments - @creator_comments
 
       if @trip.locations.length < 3
         redirect_to new_trip_location_path( @trip )

--- a/app/views/comments/_new_comment_form.html.erb
+++ b/app/views/comments/_new_comment_form.html.erb
@@ -7,11 +7,10 @@
         <li><%= message %></li>
       <% end %>
 <%end%>
-
-  <p>
-    <label for="body">Write a comment</label>
+  <label for="body">Write a comment</label>
+  <div class="input-field">
     <%=f.text_field :body, hide_label: true %>
-  </p>
+  </div>
   <%=f.hidden_field :trip_id, :value => trip.id %>
   <%=f.hidden_field :user_id, :value => current_user.id %>
   <%=f.submit "Comment" %>

--- a/app/views/comments/_new_comment_form.html.erb
+++ b/app/views/comments/_new_comment_form.html.erb
@@ -13,7 +13,7 @@
   </div>
   <%=f.hidden_field :trip_id, :value => trip.id %>
   <%=f.hidden_field :user_id, :value => current_user.id %>
-  <%=f.submit "Comment" %>
+  <%=f.submit "Comment", class: "waves-effect waves-light btn deep-orange" %>
   <a href="#" class="close-comment">cancel</a>
 <% end %>
 

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -12,14 +12,14 @@
         <% end %>
   <%end%>
 
-    <p>
+    <div class="input-field">
       <label for="body">Edit your comment</label>
       <%=f.text_field :body, hide_label: true %>
-    </p>
+    </div>
 
       <%=f.hidden_field :trip_id, :value => @trip.id %>
       <%=f.hidden_field :user_id, :value => current_user.id %>
-      <%=f.submit "Edit", class: "waves-effect waves-light btn deep-orange" %>
+      <%=f.submit "Save", class: "waves-effect waves-light btn deep-orange" %>
   <% end %>
 
   <br>

--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -4,7 +4,7 @@
         <span class="card-title"><%= conversation.subject %></span>
         <p>from: <%= conversation.originator.formatted_name %></p>
         <p><%=  conversation.messages.last.created_at.strftime("%A, %b %d, %Y at %I:%M%p") %></p>
-        <p>last message: <%= truncate conversation.messages.last.body, length: 145 %></p>
+        <p class="message-body">last message: <%= truncate conversation.messages.last.body, length: 30 %></p>
       </div>
       <div class="card-action white message-card-inbox">
         <%= link_to "View", conversation_path(conversation)  %>

--- a/app/views/conversations/_messages.html.erb
+++ b/app/views/conversations/_messages.html.erb
@@ -38,7 +38,7 @@
         <div class="col s12 m6">
           <div class="card message-card light-blue darken-2">
             <div class="card-content white-text">
-                <%= message.body %>
+                <p class="message-body"><%= message.body %></p>
             </div>
             <small class="right grey-text"><%=  message.created_at.strftime("%-m/%-d/%y %l:%M%P") %> (about <%= time_ago_in_words(message.created_at) %> ago)</small>
             <small class="left grey-text"><%=  message.sender.formatted_name %></small>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -3,7 +3,7 @@
 
  <div class="row">
   <%@tags.each do |tag| %>
-    <div class="chip grey lighten-5 bounceInDown animated">
+    <div class="chip grey lighten-5 bounceInDown animated hoverable">
       <%= link_to "##{tag.name}", tag_path(tag) %>
     </div>
   <% end %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -36,9 +36,12 @@
   <div class="col s12 m12 l6">
     <div class="creator-comments-container">
       <h5>Comments by the Trip Creator:</h5>
-      <% @trip.comments.each do |comment| %>
+      <% if @creator_comments.length == 0 %>
+        <p class="no-comments-message">No comments by the trip creator.</p>
+      <% else %>
+      <p class="no-comments-message hidden-comments-message">No comments by the trip creator.</p>
+      <% @creator_comments.each do |comment| %>
       <div class="container comment-body">
-        <% if comment.user == @trip.creator %>
         <blockquote>
         <p><%= comment.body %><span class="tiny-font">   posted <%= time_ago_in_words(comment.created_at) %> ago</span></p>
         <p>Commenter: <%= link_to comment.user.formatted_name, user_path(comment.user) %></p>
@@ -52,10 +55,10 @@
                 <i class="tiny material-icons">delete</i>
               <% end %>
             <% end %>
-          <% end %>
         <% end %>
         </blockquote>
       </div>
+      <% end %>
       <% end %>
     </div>
 
@@ -70,10 +73,13 @@
 
     <div class="not-creator-comments-container">
       <h5>Comments: </h5>
-      <% @trip.comments.each do |comment| %>
+      <% if @user_comments.length == 0 %>
+        <p class="no-comments-message">No comments for this trip currently</p>
+      <% else %>
+        <p class="no-comments-message hidden-comments-message">No comments for this trip currently</p>
+      <% @user_comments.each do |comment| %>
         <div class="container comment-body">
           <blockquote>
-            <% if comment.user != @trip.creator %>
           <p><%= comment.body %><span class="tiny-font">   posted <%= time_ago_in_words(comment.created_at) %> ago</span></p>
           <p>Commenter: <%= link_to comment.user.formatted_name, user_path(comment.user) %></p>
           <% if current_user == comment.user %>
@@ -87,14 +93,14 @@
               <% end %>
             <% end %>
           <% end %>
-          <% end %>
           </blockquote>
         </div>
+      <% end %>
       <% end %>
     </div>
 
   <% if user_signed_in? && current_user != @trip.creator %>
-    <div class="container new-comment-not-creator-button">
+    <div class="new-comment-not-creator-button">
       <%= form_for(@comment, url: new_comment_path, method: :get ) do |f| %>
         <%= hidden_field_tag "trip_id", "#{@trip.id}"  %>
         <%= f.submit "add comment", class: "waves-effect waves-light btn deep-orange" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -64,7 +64,7 @@
       <% end %>
   <% end %>
 
-  <%= f.submit "Edit", :class => "waves-effect waves-light btn-large deep-orange" %>
+  <%= f.submit "Save", :class => "waves-effect waves-light btn-large deep-orange" %>
 <% end %>
 
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,8 +34,11 @@
             <p>Trips Curated: <%= @user.trips.count %></p>
             <p>Total Trip Attendees: <%= @user.total_trip_attendees %>
             <p>Trips Attended: <%= @user.attended_trips.count %></p>
-            <% if @user.available == true %>
+            <% if @user.available == true && @user != current_user %>
               <p><%= link_to "Message To Request A Tour",new_conversation_path %></p>
+              <i class="small material-icons grey-text text-darken-3">directions_walk</i>
+            <% elsif @user.available == true %>
+              <p>Available for tours</p>
               <i class="small material-icons grey-text text-darken-3">directions_walk</i>
             <% end %>
           </div>


### PR DESCRIPTION
@hannataylor @ChristynBudzyna @elan71592 
- fix buttons for editing profile and editing comment; edit changed to save
- add message when no comments present and adjust AJAX accordingly to handle such messages
- make tags on tag index hoverable
- fix underline for comment and messaging forms to be blue
- fix AJAX for new locations on location new page; now it is removing the entire row that held the new location card, preventing the phantom divs from messing up the alignment of the two columns
